### PR TITLE
refactor: Create Syncer to manage sync logic

### DIFF
--- a/cmd/shiftsync/main.go
+++ b/cmd/shiftsync/main.go
@@ -1,16 +1,11 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
 
-	"github.com/kiyanmair/shift-sync/config"
-	"github.com/kiyanmair/shift-sync/internal/destination"
-	"github.com/kiyanmair/shift-sync/internal/source"
 	"github.com/kiyanmair/shift-sync/internal/sync"
 )
 
@@ -22,49 +17,8 @@ func main() {
 		Use:   "run",
 		Short: "Execute syncs from sources to destinations",
 		Run: func(cmd *cobra.Command, args []string) {
-			cfg, err := config.LoadConfig(configPath)
-			if err != nil {
-				log.Fatalf("Failed to load config: %v", err)
-			}
-
-			sources := make(map[string]source.Source)
-			for _, srcCfg := range cfg.Sources {
-				src, err := source.NewSource(srcCfg)
-				if err != nil {
-					log.Printf("Failed to create source %s: %v", srcCfg.ID, err)
-					continue
-				}
-				sources[srcCfg.ID] = src
-			}
-
-			destinations := make(map[string]destination.Destination)
-			for _, destCfg := range cfg.Destinations {
-				dest, err := destination.NewDestination(destCfg)
-				if err != nil {
-					log.Printf("Failed to create destination %s: %v", destCfg.ID, err)
-					continue
-				}
-				destinations[destCfg.ID] = dest
-			}
-
-			var errs []error
-			for _, syncCfg := range cfg.Syncs {
-				err := sync.Sync(syncCfg, sources, destinations)
-				if err != nil {
-					errs = append(errs, err)
-					continue
-				}
-				log.Printf("Synced source %s to destination %s", syncCfg.SourceID, syncCfg.DestinationID)
-			}
-
-			numTotal := len(cfg.Syncs)
-			numFailed := len(errs)
-			numSuccessful := numTotal - numFailed
-
-			log.Printf("Completed %d/%d syncs", numSuccessful, numTotal)
-			if numFailed > 0 {
-				log.Fatalf("Encountered errors:\n%v", errors.Join(errs...))
-			}
+			syncer := sync.NewSyncer(configPath)
+			syncer.RunSyncs()
 		},
 	}
 

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1,21 +1,41 @@
 package sync
 
 import (
+	"errors"
 	"fmt"
+	"log"
 
 	"github.com/kiyanmair/shift-sync/config"
-	"github.com/kiyanmair/shift-sync/internal/destination"
-	"github.com/kiyanmair/shift-sync/internal/source"
 )
 
-func Sync(syncCfg config.Sync, sources map[string]source.Source, destinations map[string]destination.Destination) error {
-	source, sourceExists := sources[syncCfg.SourceID]
-	if !sourceExists {
+func (s *Syncer) RunSyncs() {
+	var errs []error
+	for _, syncCfg := range s.cfg.Syncs {
+		if err := s.singleSync(syncCfg); err != nil {
+			errs = append(errs, err)
+		} else {
+			log.Printf("Synced source %s to destination %s", syncCfg.SourceID, syncCfg.DestinationID)
+		}
+	}
+
+	numTotal := len(s.cfg.Syncs)
+	numFailed := len(errs)
+	numSuccessful := numTotal - numFailed
+
+	log.Printf("Completed %d/%d syncs", numSuccessful, numTotal)
+	if numFailed > 0 {
+		log.Fatalf("Encountered errors:\n%v", errors.Join(errs...))
+	}
+}
+
+func (s *Syncer) singleSync(syncCfg config.Sync) error {
+	source, exists := s.sources[syncCfg.SourceID]
+	if !exists {
 		return fmt.Errorf("source %s not found", syncCfg.SourceID)
 	}
 
-	dest, destExists := destinations[syncCfg.DestinationID]
-	if !destExists {
+	dest, exists := s.destinations[syncCfg.DestinationID]
+	if !exists {
 		return fmt.Errorf("destination %s not found", syncCfg.DestinationID)
 	}
 

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -1,0 +1,50 @@
+package sync
+
+import (
+	"log"
+
+	"github.com/kiyanmair/shift-sync/config"
+	"github.com/kiyanmair/shift-sync/internal/destination"
+	"github.com/kiyanmair/shift-sync/internal/source"
+)
+
+type Syncer struct {
+	cfg          *config.Config
+	sources      map[string]source.Source
+	destinations map[string]destination.Destination
+}
+
+func NewSyncer(configPath string) *Syncer {
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		log.Fatalf("Failed to load config: %v", err)
+	}
+
+	sources := make(map[string]source.Source)
+	for _, srcCfg := range cfg.Sources {
+		src, err := source.NewSource(srcCfg)
+		if err != nil {
+			log.Printf("Failed to create source %s: %v", srcCfg.ID, err)
+			continue
+		}
+		sources[srcCfg.ID] = src
+	}
+
+	destinations := make(map[string]destination.Destination)
+	for _, destCfg := range cfg.Destinations {
+		dest, err := destination.NewDestination(destCfg)
+		if err != nil {
+			log.Printf("Failed to create destination %s: %v", destCfg.ID, err)
+			continue
+		}
+		destinations[destCfg.ID] = dest
+	}
+
+	syncer := Syncer{
+		cfg:          cfg,
+		sources:      sources,
+		destinations: destinations,
+	}
+
+	return &syncer
+}


### PR DESCRIPTION
This PR implements a `Syncer` struct, its constructor, and its methods `RunSyncs` and `singleSync`, to manage the sync logic. This removes that logic from the CLI tool, so that it only has to create a `Syncer` from the config and `RunSyncs`. Resolves #9.